### PR TITLE
Increment adapter version to 2.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
-# 2.2.0
+# 2.1.2
 
-- Add parameter for Unified ID in `__generateRequestObj` function of adapter code
+- Add support for Unified ID in `__generateRequestObj` function of adapter code
+- Also adds support for signaling ability of request to support bids requiring HTML5 Video support
 
 # 2.1.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,7 @@
+# 2.2.0
+
+- Add parameter for Unified ID in `__generateRequestObj` function of adapter code
+
+# 2.1.1
+
+- Initial version certified by IX

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "share-through-module",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "share-through-module",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "description": "a complete self-serve partner development package for the header tag wrapper",
   "main": "share-through-htb.js",
   "scripts": {

--- a/share-through-htb.js
+++ b/share-through-htb.js
@@ -90,7 +90,7 @@ function ShareThroughHtb(configs) {
             bidId: returnParcels[0].requestId,
             instant_play_capable: __canAutoPlayHTML5Video(),
             hbSource: "indexExchange",
-            hbVersion: "2.1.1",
+            hbVersion: "2.1.2",
             cbust: System.now()
         };
 
@@ -339,7 +339,7 @@ function ShareThroughHtb(configs) {
             partnerId: 'ShareThroughHtb', // PartnerName
             namespace: 'ShareThroughHtb', // Should be same as partnerName
             statsId: 'SHTH', // Unique partner identifier
-            version: '2.1.1',
+            version: '2.1.2',
             targetingType: 'slot',
             enabledAnalytics: {
                 requestTime: true

--- a/spec/generateRequestObj.spec.js
+++ b/spec/generateRequestObj.spec.js
@@ -169,7 +169,7 @@ describe('generateRequestObj', function () {
                 expect(requestObject.data.instant_play_capable).to.be.true;
                 expect(requestObject.data.ttduid).to.eq('uid123');
                 expect(requestObject.data.hbSource).to.eq('indexExchange');
-                expect(requestObject.data.hbVersion).to.eq('2.1.1');
+                expect(requestObject.data.hbVersion).to.eq('2.1.2');
                 expect(requestObject.data.cbust).to.exist;
                 expect(requestObject.data.consent_required).to.eq(true);
                 expect(requestObject.data.consent_string).to.eq('BOQ7WlgOQ7WlgABABwAAABJOACgACAAQABA');


### PR DESCRIPTION
@javadreamer draft of our responses for IX's Adapter Update Form included below for your review. The form itself can be found [here](
https://jira.indexexchange.com/servicedesk/customer/portal/15/create/311).

```
Ticket Title:
Sharethrough - Adapter Update - Unified ID Support

Pull Request:
PULL_REQUEST_URL

Description of Change:
Sharethrough's adapter code now takes advantage of the Unified ID Solution provided by Index Exchange and passes this information to its ad server.

Change Category:
[ ] Bug Fix
[x] New Feature - Reporting
[ ] New Feature - Performance
[ ] New Feature - Other
```

Story: https://www.pivotaltracker.com/story/show/162802815
[#162802815]